### PR TITLE
Use row format for share modals on mobile widths 

### DIFF
--- a/src/components/editor/share-modal/style.css
+++ b/src/components/editor/share-modal/style.css
@@ -1,7 +1,6 @@
 .editor-share-modal__links {
   display: grid;
   grid-template-rows: 1fr;
-  align-items: top;
 }
 
 @media screen and (min-width: 600px) {
@@ -9,7 +8,6 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: calc(var(--grid-unit) * 2);
-    align-items: top;
   }
 }
 

--- a/src/components/editor/share-modal/style.css
+++ b/src/components/editor/share-modal/style.css
@@ -1,8 +1,16 @@
 .editor-share-modal__links {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-gap: calc(var(--grid-unit) * 2);
-	align-items: top;
+  display: grid;
+  grid-template-rows: 1fr;
+  align-items: top;
+}
+
+@media screen and (min-width: 600px) {
+  .editor-share-modal__links {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: calc(var(--grid-unit) * 2);
+    align-items: top;
+  }
 }
 
 .editor-share-modal__copy {

--- a/src/components/editor/share-modal/style.css
+++ b/src/components/editor/share-modal/style.css
@@ -1,6 +1,7 @@
 .editor-share-modal__links {
   display: grid;
   grid-template-rows: 1fr;
+  grid-gap: calc(var(--grid-unit) * 2);
 }
 
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
On mobile widths, the share modal is cut off currently. 

| Desktop | Mobile |
|------|------|
| <img width="664" alt="Screenshot 2020-06-12 at 00 20 48" src="https://user-images.githubusercontent.com/18581859/84428083-81483200-ac43-11ea-99ca-f517c041312f.png"> | <img width="407" alt="Screenshot 2020-06-12 at 00 21 01" src="https://user-images.githubusercontent.com/18581859/84428078-7db4ab00-ac43-11ea-82c2-7311e1fea625.png"> |

With the proposed changes, at 600px and above, the share modals will appear in column tracks. Below that, they shall appear on row track:

| Desktop | Mobile |
|------|------|
| <img width="680" alt="Screenshot 2020-06-12 at 00 21 32" src="https://user-images.githubusercontent.com/18581859/84428166-a5a40e80-ac43-11ea-8e26-19d0c280d3c6.png"> | <img width="364" alt="Screenshot 2020-06-12 at 00 21 15" src="https://user-images.githubusercontent.com/18581859/84428178-a9d02c00-ac43-11ea-8923-d3e68635d5cf.png"> |

Also removes unused `align-top` rule in the grid.