### PR TITLE
Save comment context

### DIFF
--- a/src/components/editor/filters/comment.js
+++ b/src/components/editor/filters/comment.js
@@ -14,15 +14,33 @@ function BlockCommentsControls( { clientId } ) {
 		getSelectedComment,
 		selectionStart,
 		selectionEnd,
-	} = useSelect(
-		( select ) => ( {
+		selectedText,
+	} = useSelect( ( select ) => {
+		const _selectionEnd = select( 'core/block-editor' ).getSelectionEnd();
+		const _selectionStart = select(
+			'core/block-editor'
+		).getSelectionStart();
+
+		let _selectedText = null;
+		const { offset: startOffset, attributeKey } = _selectionStart;
+		const { offset: endOffset } = _selectionEnd;
+
+		// we only support storing text now.
+		if ( attributeKey === 'content' ) {
+			const block = select( 'core/block-editor' ).getBlock( clientId );
+			_selectedText = block.attributes[ attributeKey ].slice(
+				startOffset,
+				endOffset
+			);
+		}
+		return {
 			getEditedProperty: select( 'asblocks' ).getEditedProperty,
 			getSelectedComment: select( 'asblocks' ).getSelectedComment,
-			selectionEnd: select( 'core/block-editor' ).getSelectionEnd(),
-			selectionStart: select( 'core/block-editor' ).getSelectionStart(),
-		} ),
-		[]
-	);
+			selectionEnd: _selectionEnd,
+			selectionStart: _selectionStart,
+			selectedText: _selectedText,
+		};
+	}, [] );
 
 	const { addComment, selectComment } = useDispatch( 'asblocks' );
 	const [ authorId ] = useAuthorId();
@@ -31,6 +49,7 @@ function BlockCommentsControls( { clientId } ) {
 		addComment( {
 			start: selectionStart,
 			end: selectionEnd,
+			context: selectedText,
 			type: 'block',
 			_id: uuidv4(),
 			content: '',


### PR DESCRIPTION
This pull adds comment context (selected text for that comment), I haven't yet decided how to show it yet, this is essential for unattached comments, I don't know if there's a more straightforward way of getting the selected text from the editor.

### limitations
- Currently, this only supports text-based comments (comments created from text selection).
- It saves the original selected text, if you edit that text, the context won't update, this is by design.

### Testing
You can console log the `addComment` action generator or the edit object to see the selected text saved under `context`, it will be `null` for other non-text based comments.