### PR TITLE
Add a local document list

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,6 +11,7 @@
 		"no-duplicate-selectors": null,
 		"rule-empty-line-before": null,
 		"selector-class-pattern": null,
-		"value-keyword-case": null
+		"value-keyword-case": null,
+		"function-parentheses-space-inside": null
 	}
 }

--- a/src/components/editor/header/index.js
+++ b/src/components/editor/header/index.js
@@ -7,16 +7,14 @@ import { useMutation } from '../../../lib/data';
 import { savePost, sharePost } from '../../../api/posts';
 import { keyToString } from '../../../lib/crypto';
 import './style.css';
+import { useLocalPostSave } from '../../../local-storage';
 
 export function EditorHeader( {
-	//	persistedPost,
-	//	editedPost,
 	isInspectorOpened,
 	onOpenInspector,
 	setIsShareModalOpened,
 	encryptionKey,
 	ownerKey,
-	//	onPersist,
 } ) {
 	const { peersCount, isShared, isDirty, getEdits, getPersisted } = useSelect(
 		( select ) => {
@@ -31,6 +29,7 @@ export function EditorHeader( {
 		},
 		[]
 	);
+	const setLocalPost = useLocalPostSave();
 	const { persist } = useDispatch( 'asblocks' );
 	const { mutate: mutateShare, loading: isSharing } = useMutation(
 		sharePost
@@ -45,6 +44,13 @@ export function EditorHeader( {
 			ownerKey
 		);
 		persist( persisted, edits );
+		const newStringKey = await keyToString( encryptionKey );
+		setLocalPost( {
+			_id: persisted._id,
+			ownerKey,
+			title: persisted.title,
+			key: newStringKey,
+		} );
 	};
 
 	const triggerShare = async () => {
@@ -57,6 +63,12 @@ export function EditorHeader( {
 			'/write/' + persisted._id + '/' + ownerKey + '#key=' + newStringKey
 		);
 		setIsShareModalOpened( true );
+		setLocalPost( {
+			_id: persisted._id,
+			ownerKey,
+			title: persisted.title,
+			key: newStringKey,
+		} );
 	};
 
 	return (

--- a/src/components/logo/index.js
+++ b/src/components/logo/index.js
@@ -1,8 +1,10 @@
 import { Button, Dropdown } from '@wordpress/components';
 import { DarkModeToggle } from '../dark-mode-toggle';
+import { useLocalPostList } from '../../local-storage';
 import './style.css';
 
 export function Logo() {
+	const [ postList ] = useLocalPostList();
 	return (
 		<Dropdown
 			renderToggle={ ( { onToggle, isOpen } ) => (
@@ -29,7 +31,7 @@ export function Logo() {
 			) }
 			renderContent={ () => (
 				<div className="logo-dropdown">
-					<div className="logo-dropdown-menu">
+					<div className="logo-dropdown-menu logo__about">
 						<strong>AsBlocks</strong> is an{ ' ' }
 						<a href="https://en.wikipedia.org/wiki/End-to-end_encryption">
 							end-to-end encrypted
@@ -45,11 +47,31 @@ export function Logo() {
 						.
 					</div>
 
-					<div className="logo-dropdown-menu">
-						<Button isPrimary href="/">
-							New Document
-						</Button>
-					</div>
+					{ !! postList?.length && (
+						<div className="logo-dropdown-menu">
+							<div className="logo__main-menu-header">
+								<h3>Document List</h3>
+								<Button isPrimary href="/">
+									New
+								</Button>
+							</div>
+
+							<ul className="logo__main-menu">
+								{ postList.map( ( post ) => {
+									const url = post.ownerKey
+										? `${ window.location.origin }/write/${ post._id }/${ post.ownerKey }#key=${ post.key }`
+										: `${ window.location.origin }/read/${ post._id }#key=${ post.key }`;
+									return (
+										<li key={ post._id }>
+											<Button href={ url }>
+												{ post.title }
+											</Button>
+										</li>
+									);
+								} ) }
+							</ul>
+						</div>
+					) }
 
 					<div className="logo-dropdown-menu">
 						<h3>Options</h3>

--- a/src/components/logo/style.css
+++ b/src/components/logo/style.css
@@ -5,7 +5,7 @@
 }
 
 .logo.components-button svg {
-	fill: var(--theme-color);
+	fill: var( --theme-color );
 	margin-right: 0 !important;
 }
 
@@ -25,9 +25,34 @@
 }
 
 .logo-dropdown-menu {
-	padding: calc(var(--grid-unit) * 1.5);
+	padding: calc( var( --grid-unit ) * 1.5 );
 }
 
 .logo-dropdown-menu + .logo-dropdown-menu {
-	border-top: 1px solid #000;
+	border-top: 1px solid #bbb;
+}
+
+.logo__about {
+	font-size: 0.9em;
+}
+
+.logo__main-menu-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.logo__main-menu-header h3 {
+	margin: 0;
+}
+
+.logo__main-menu {
+	list-style: none;
+	padding: 0;
+	margin-bottom: 0;
+}
+
+.logo__main-menu a.components-button {
+	font-weight: 500;
+	padding: 0;
 }

--- a/src/components/route-read/index.js
+++ b/src/components/route-read/index.js
@@ -1,15 +1,25 @@
+import { useEffect } from '@wordpress/element';
 import usePromise from 'react-promise-suspense';
 import { useParams } from 'react-router-dom';
 import { PostRender } from '../post-render';
 import { fetchPost } from '../../api/posts';
 import { useSuspendedApi } from '../../lib/data';
 import { stringToKey } from '../../lib/crypto';
+import { useLocalPostSave } from '../../local-storage';
 
 export function RouteRead() {
 	const { id } = useParams();
 	const stringKey = window.location.hash.slice( '#key='.length );
 	const encryptionKey = usePromise( stringToKey, [ stringKey ] );
 	const post = useSuspendedApi( fetchPost, [ id, encryptionKey ] );
+	const setLocalPost = useLocalPostSave();
+	useEffect( () => {
+		setLocalPost( {
+			_id: id,
+			title: post.title,
+			key: stringKey,
+		} );
+	}, [ id, post, stringKey ] );
 
 	return <PostRender post={ post } />;
 }

--- a/src/components/route-write/index.js
+++ b/src/components/route-write/index.js
@@ -6,6 +6,7 @@ import { Editor } from '../editor';
 import { fetchPost } from '../../api/posts';
 import { useSuspendedApi } from '../../lib/data';
 import { stringToKey } from '../../lib/crypto';
+import { useLocalPostSave } from '../../local-storage';
 
 export function RouteWrite() {
 	const { id, ownerKey } = useParams();
@@ -13,8 +14,17 @@ export function RouteWrite() {
 	const encryptionKey = usePromise( stringToKey, [ stringKey ] );
 	const post = useSuspendedApi( fetchPost, [ id, encryptionKey ] );
 	const { persist } = useDispatch( 'asblocks' );
+	const setLocalPost = useLocalPostSave();
 	useEffect( () => {
 		persist( post );
 	}, [ post ] );
+	useEffect( () => {
+		setLocalPost( {
+			_id: id,
+			title: post.title,
+			key: stringKey,
+			ownerKey,
+		} );
+	}, [ id, post, stringKey ] );
 	return <Editor encryptionKey={ encryptionKey } ownerKey={ ownerKey } />;
 }

--- a/src/local-storage/index.js
+++ b/src/local-storage/index.js
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { createLocalStorageStateHook } from 'use-local-storage-state';
+import { useCallback } from '@wordpress/element';
 
 export const useDarkMode = createLocalStorageStateHook( 'dark-mode', false );
 export const useAuthorId = createLocalStorageStateHook( 'author-id', uuidv4() );
@@ -7,3 +8,29 @@ export const useAuthorName = createLocalStorageStateHook(
 	'author-name',
 	'Anonymous'
 );
+export const useLocalPostList = createLocalStorageStateHook( 'post-list', [] );
+export const useLocalPostSave = () => {
+	const [ postList, setPostList ] = useLocalPostList();
+
+	const setPost = useCallback(
+		( newPost ) => {
+			const id = newPost._id;
+			const index = postList.findIndex( ( p ) => p._id === id );
+			if ( index !== undefined ) {
+				setPostList( [
+					...postList.slice( 0, index ),
+					{
+						...postList[ index ],
+						...newPost,
+					},
+					...postList.slice( index + 1 ),
+				] );
+			} else {
+				setPostList( [ ...postList, newPost ] );
+			}
+		},
+		[ postList ]
+	);
+
+	return setPost;
+};


### PR DESCRIPTION
It's a bit tedious to have to remember URLs with keys. This PR adds a post list into local storage,  just click the logo and you'll access your previous posts

<img width="277" alt="Capture d’écran 2020-06-27 à 5 10 02 PM" src="https://user-images.githubusercontent.com/272444/85926716-2c3e2a00-b899-11ea-96fb-2ff7ef12af9b.png">

There's a lot of things that can be done in terms of UI (for instance use a panel instead of dropdown, search...) but this should be a decent start.